### PR TITLE
feat: support ESLint v6

### DIFF
--- a/configs/eslint.js
+++ b/configs/eslint.js
@@ -101,8 +101,7 @@ module.exports = {
         ignoreReadBeforeAssign: true,
       },
     ],
-    'prefer-spread': 'warn',
-    'no-console': 'off',
+    'prefer-spread': 'warn'
   },
   overrides: [
     {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typescript": "^3.4.5"
   },
   "peerDependencies": {
-    "eslint": "^5.16.0",
+    "eslint": "^6.0.1",
     "prettier": "^1.17.0",
     "react": "^16.8.6",
     "typescript": "^3.4.5"

--- a/test/fixtures/Counter.tsx
+++ b/test/fixtures/Counter.tsx
@@ -6,6 +6,7 @@ interface Props {
 
 const Counter: React.FC<Props> = props => {
   const [count, setCount] = useState(props.initialCount)
+  console.log(count)
   return (
     <main>
       <p className='text'>{count}</p>


### PR DESCRIPTION
BREAKING CHANGE: ESLint v5 is no longer supported

`no-console` has been removed from `eslint:recommended` so we don't have to disable the rule explicitly.