### PR TITLE
fix: fix no-shadow settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,8 @@ module.exports = {
   extends: ['./configs/eslint.js', './configs/typescript.js', './configs/react.js'],
   rules: {
     '@typescript-eslint/no-var-requires': 'off',
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-shadow.md
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': ['error'],
   },
 }

--- a/test/__snapshots__/run.test.js.snap
+++ b/test/__snapshots__/run.test.js.snap
@@ -21,7 +21,7 @@ Object {
     "errors": Array [
       "default-param-last",
       "prefer-regex-literals",
-      "no-shadow",
+      "@typescript-eslint/no-shadow",
       "prettier/prettier",
     ],
     "warnings": Array [


### PR DESCRIPTION
`no-shadow` の rule 設定に不備があり `enum` で lint エラーになる現象を修正

参考：https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-shadow.md