### PR TITLE
fix: apply eslint-config-prettier correctly

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ['./index.js']
+  extends: ['./index.js'],
 }

--- a/configs/eslint.js
+++ b/configs/eslint.js
@@ -26,7 +26,7 @@ module.exports = {
       'error',
       {
         ignoreDeclarationSort: true,
-      }
+      },
     ],
     'no-iterator': 'error',
     'no-lone-blocks': 'error',
@@ -110,7 +110,7 @@ module.exports = {
         ignoreReadBeforeAssign: true,
       },
     ],
-    'prefer-spread': 'warn'
+    'prefer-spread': 'warn',
   },
   overrides: [
     {

--- a/configs/eslint.js
+++ b/configs/eslint.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['eslint:recommended', 'plugin:prettier/recommended'],
+  extends: ['eslint:recommended'],
   plugins: [],
   parserOptions: {
     ecmaVersion: 2018,

--- a/configs/prettier.js
+++ b/configs/prettier.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['plugin:prettier/recommended'],
+}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 module.exports = {
-  extends: ['./configs/eslint.js', './configs/typescript.js', './configs/react.js'],
+  extends: [
+    './configs/eslint.js',
+    './configs/typescript.js',
+    './configs/react.js',
+    './configs/prettier.js',
+  ],
   rules: {
     '@typescript-eslint/no-var-requires': 'off',
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-shadow.md

--- a/test/__snapshots__/run.test.js.snap
+++ b/test/__snapshots__/run.test.js.snap
@@ -6,7 +6,6 @@ Object {
     "errors": Array [
       "prettier/prettier",
       "prettier/prettier",
-      "jsx-quotes",
     ],
     "warnings": Array [
       "react/no-children-prop",

--- a/test/fixtures/Counter.tsx
+++ b/test/fixtures/Counter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 interface Props {
   initialCount: number
@@ -7,6 +7,13 @@ interface Props {
 const Counter: React.FC<Props> = props => {
   const [count, setCount] = useState(props.initialCount)
   console.log(count)
+
+  useEffect(() => {
+    ;(() => {
+      console.log('do something')
+    })()
+  }, [])
+
   return (
     <main>
       <p className='text'>{count}</p>


### PR DESCRIPTION
## What I want

This PR changed the order of prettier config, and it broke some existing rules, which I want to fix.
https://github.com/kufu/eslint-config-smarthr/pull/292

To be specific, the config for semicolon was conflicting between `@typescript-eslint` and `eslint-config-prettier`

![image](https://user-images.githubusercontent.com/14817308/113665675-dbd9df80-96e8-11eb-89b0-8cd83ed0b67f.png)

![image](https://user-images.githubusercontent.com/14817308/113665634-c2d12e80-96e8-11eb-878d-ffdb607fa8b0.png)



## What I did

- cut out the prettier settings as a separate file to let it extended at the last https://github.com/kufu/eslint-config-smarthr/commit/dec908c25a831affcd963f6da2894e566c43cfeb
- updated the snapshot https://github.com/kufu/eslint-config-smarthr/commit/97c4e0df9fdf4b9878a84b8e01e6cff411f75bd8
  - the deleted line was a duplicated thing (the second `"prettier/prettier"` and the deleted `"jsx-quotes"` were indicating the same error)
- add some code to the `Counter` component to test semicolon config https://github.com/kufu/eslint-config-smarthr/commit/44358bd43037ea1e63acd9540b99c33bc9c09a23
- run format https://github.com/kufu/eslint-config-smarthr/commit/c7cc8687608fbe04db14c2eede72ee223c76059d