### PR TITLE
chore(release): 6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [6.0.1](https://github.com/kufu/eslint-config-smarthr/compare/v6.0.0...v6.0.1) (2021-12-01)
+
 ## [6.0.0](https://github.com/kufu/eslint-config-smarthr/compare/v5.0.3...v6.0.0) (2021-11-16)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-smarthr",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "A sharable ESLint config for SmartHR",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`eslint-plugin-react-hooks`v4.2.0をv4.3.0に上げるためのパッチアップデートです。
https://github.com/facebook/react/issues/22545