### PR TITLE
update: eslint-config-smarthr

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2204,7 +2204,7 @@ eslint-plugin-react@^7.28.0:
 
 "eslint-plugin-smarthr@https://github.com/kufu/eslint-plugin-smarthr":
   version "0.0.0"
-  resolved "https://github.com/kufu/eslint-plugin-smarthr#c0607969e183787f66070a1a0051475f676cbe03"
+  resolved "https://github.com/kufu/eslint-plugin-smarthr#93ff112a83328539ff8ec4738e48164144a973b5"
   dependencies:
     fs "^0.0.1-security"
     json5 "^2.2.0"


### PR DESCRIPTION
- eslint-plugin-smarthrを更新します
  - format-import-path: import path に `xxxx/index` のように index.ts などを指定している場合、自動的に省略する処理を追加
  - prohibit-import:  `import { hoge } from 'fuga'` 以外にも `import hoge from 'fuga'` 記法にも対応できるように修正
  - redundant-name: 修正対象の指定条件ミスを修正

修正詳細
- https://github.com/kufu/eslint-plugin-smarthr/commits/main