### PR TITLE
chore: update eslint-plugin-smarthr

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-smarthr": "^0.2.1"
+    "eslint-plugin-smarthr": "^0.2.2"
   },
   "jest": {
     "moduleNameMapper": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2318,10 +2318,10 @@ eslint-plugin-react@^7.30.1:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.7"
 
-eslint-plugin-smarthr@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.2.1.tgz#bc0a4965603a46eafa3e17bf33404a1be3de2834"
-  integrity sha512-HiQE4UBeDKaDCvDd2uxYWkhI/OXqwDkqRAxxFdhQNdFqF5xjJNgWcbAtb2mFphzGZgkacZNYDsMycOGQpjp2PQ==
+eslint-plugin-smarthr@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.2.2.tgz#3c3c5f6750d71614c5a59922433b1a95804ac43d"
+  integrity sha512-kJOoXMfGd55omzBKTG9H7G979S6F1tGTdX6Xdsh8rRVi8ClNo7ISiosAEJFZpkQvWbJ+fLnEa0WbyZwMq9e8dg==
   dependencies:
     inflected "^2.1.0"
     json5 "^2.2.0"


### PR DESCRIPTION
- smarthr/redundant-name の allowedNames が一部無視されるバグが修正されます