### PR TITLE
feat: eslint-plugin-smarthrのおすすめルールをdefault errorにする

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,16 +13,17 @@ module.exports = {
     'no-shadow': 'off',
 
     // original rules
-    'smarthr/a11y-clickable-element-has-text': 'off',
-    'smarthr/a11y-image-has-alt-attribute': 'off',
-    'smarthr/a11y-trigger-has-button': 'off',
-    'smarthr/format-import-path': 'off',
-    'smarthr/format-translate-component': 'off',
-    'smarthr/jsx-start-with-spread-attributes': 'off',
-    'smarthr/no-import-other-domain': 'off',
-    'smarthr/prohibit-import': 'off',
-    'smarthr/redundant-name': 'off',
-    'smarthr/require-import': 'off',
-    'smarthr/require-barrel-import': 'off',
+    'smarthr/a11y-clickable-element-has-text': 'error',
+    'smarthr/a11y-image-has-alt-attribute': 'error',
+    'smarthr/a11y-trigger-has-button': 'error',
+    'smarthr/best-practice-for-date': 'error',
+    'smarthr/jsx-start-with-spread-attributes': [
+      'error',
+      {
+        fix: true,
+      },
+    ],
+    'smarthr/prohibit-export-array-type': 'error',
+    'smarthr/require-barrel-import': 'error',
   },
 }

--- a/index.js
+++ b/index.js
@@ -17,13 +17,16 @@ module.exports = {
     'smarthr/a11y-image-has-alt-attribute': 'error',
     'smarthr/a11y-trigger-has-button': 'error',
     'smarthr/best-practice-for-date': 'error',
-    'smarthr/jsx-start-with-spread-attributes': [
-      'error',
-      {
-        fix: true,
-      },
-    ],
+    'smarthr/format-import-path': 'off',
+    'smarthr/format-translate-component': 'off',
+    'smarthr/jsx-start-with-spread-attributes': [ 'error', { fix: true } ],
+    'smarthr/no-import-other-domain': 'off',
     'smarthr/prohibit-export-array-type': 'error',
+    'smarthr/prohibit-file-name': 'off',
+    'smarthr/prohibit-import': 'off',
+    'smarthr/redundant-name': 'off',
     'smarthr/require-barrel-import': 'error',
+    'smarthr/require-export': 'off',
+    'smarthr/require-import': 'off',
   },
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.31.6",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-smarthr": "^0.2.4"
+    "eslint-plugin-smarthr": "^0.2.6"
   },
   "jest": {
     "moduleNameMapper": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,8 +40,8 @@
 
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
+    "paths": { "@/*": ["client/src/*"] },     /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2314,10 +2314,10 @@ eslint-plugin-react@^7.31.6:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.7"
 
-eslint-plugin-smarthr@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.2.4.tgz#7fa43c48c3e7c0b034de032dfd292d0f7af1c09d"
-  integrity sha512-nRzgbEDOaPByW+cFeZGkVkZlhZI6Rfplo+T5mNgm/cRHyZ/daxERdB0gu4cnrszg4SiI/MDOvu14pu/df+0e6Q==
+eslint-plugin-smarthr@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.2.6.tgz#45c0b3fed21955335ab7924fb7a967aeefe93150"
+  integrity sha512-zkduskZmOCvtCUyuO76SmsLcwRKvmQ0+aFgjT+TDUH6joZ7d/4d7xey1y0mMEkiaqpKoSKRF1cytYen8kSZnuw==
   dependencies:
     inflected "^2.1.0"
     json5 "^2.2.0"


### PR DESCRIPTION
以下のルールを初期値でerrorにします
- smarthr/a11y-clickable-element-has-text
- smarthr/a11y-image-has-alt-attribute
- smarthr/a11y-trigger-has-button
- smarthr/best-practice-for-date
- smarthr/jsx-start-with-spread-attributes
- smarthr/prohibit-export-array-type
- smarthr/require-barrel-import

