### PR TITLE
chore: update eslint-plugin-smarthr

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.0",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-smarthr": "^0.2.20"
+    "eslint-plugin-smarthr": "^0.2.21"
   },
   "jest": {
     "moduleNameMapper": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,10 +2201,10 @@ eslint-plugin-react@^7.32.0:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.8"
 
-eslint-plugin-smarthr@^0.2.20:
-  version "0.2.20"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.2.20.tgz#750fd08c777551fa3974fabcdce4280d61e1062b"
-  integrity sha512-G+ms4CpazOFC3dwb5vDHTfojL6s+lHtVF0MXNi90WS86bBTbMaNDd04yA/ueHVae4zuN+SJJTHb6OksIRw9yVQ==
+eslint-plugin-smarthr@^0.2.21:
+  version "0.2.21"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.2.21.tgz#80276134198adf48b15f39a44182c66940d716d9"
+  integrity sha512-eEGciPjXykfa+pgyV23fYK8sC9Y7ojUcRiPKqsB9jkmyzVEhfp9VwaFvh62aZqu60Yrcx/aUKZA7JvA2CgFFpQ==
   dependencies:
     inflected "^2.1.0"
     json5 "^2.2.0"


### PR DESCRIPTION
- a11y系ルールの共通処理である `styled-components で extendsする際の名称を縛る` 処理で、対象とするべき変数に漏れがあったため対応