### PR TITLE
feat: update eslint-plugin-smarthr (a11y-anchor-has-href-attribute に nextjs, react_router オプションを追加)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-smarthr": "^0.2.23"
+    "eslint-plugin-smarthr": "^0.2.24"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,10 +2201,10 @@ eslint-plugin-react@^7.32.2:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.8"
 
-eslint-plugin-smarthr@^0.2.23:
-  version "0.2.23"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.2.23.tgz#d152daae104d76c776f9bb9ced5c31f50eb101f8"
-  integrity sha512-H4EBZ6vFHMaeAfdGGK5t74nsDpqvHqDu4yapi7DbJlu5+i7UmpE+45IeVCVgfz9lIBkvreyEaeDgbdphT8ft3g==
+eslint-plugin-smarthr@^0.2.24:
+  version "0.2.24"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.2.24.tgz#dd70203ba9ca53fe5ffc04236cd380be39f7dd8b"
+  integrity sha512-e7zdsH10TfCjpV1CntYJWDAWtgcUKpYQn34TtsDehxea6MxZeOSWDDKMFwOE7TNihqgc51B3U2FHD5vZejIINQ==
   dependencies:
     inflected "^2.1.0"
     json5 "^2.2.0"


### PR DESCRIPTION
- `a11y-anchor-has-href-attribute` ルールに nextjs, react_routerを利用している場合向けのオプションを追加します