### PR TITLE
peerDependencies で利用できないバージョンを指定していた問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "eslint": "^7.0.0 || ^8.0.0",
-    "eslint-plugin-smarthr": "^0.1.1 || ^0.2.0 || ^0.3.0",
+    "eslint-plugin-smarthr": "^0.3.2",
     "prettier": "^1.17.0 || ^2.0.0 || ^3.0.0",
     "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
     "typescript": "^3.4.5 || ^4.0.0 || ^5.0.0"


### PR DESCRIPTION
現状の `peerDependencies` では `"eslint-plugin-smarthr": "^0.1.1 || ^0.2.0 || ^0.3.0"` のような幅を持たせた指定方法になっています。

しかし、  `'smarthr/a11y-heading-in-sectioning-content': 'error',` といったルールで指定されている `a11-heading-in-sectioning-content` が eslint-plugin-smarhr に登場するのは 0.3.2 からであり、それよりも前のバージョンで利用しようとすると `Definition for rule 'smarthr/a11y-heading-in-sectioning-content' was not found` となり落ちます。

問題が起きないバージョンを指定するよう peerDependencies の内容を修正しました。