### PR TITLE
Update eslint plugin smarthr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [6.12.2](https://github.com/kufu/eslint-config-smarthr/compare/v6.12.1...v6.12.2) (2023-09-27)
+
 ### [6.12.1](https://github.com/kufu/eslint-config-smarthr/compare/v6.12.0...v6.12.1) (2023-09-20)
 
 ## [6.12.0](https://github.com/kufu/eslint-config-smarthr/compare/v6.11.0...v6.12.0) (2023-09-04)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-smarthr",
-  "version": "6.12.1",
+  "version": "6.12.2",
   "description": "A sharable ESLint config for SmartHR",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-smarthr": "^0.3.11"
+    "eslint-plugin-smarthr": "^0.3.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2320,10 +2320,10 @@ eslint-plugin-react@^7.33.2:
     semver "^6.3.1"
     string.prototype.matchall "^4.0.8"
 
-eslint-plugin-smarthr@^0.3.11:
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.3.11.tgz#ffee16d1012ec7d9aacc5695b24f5812f9c9a7d8"
-  integrity sha512-f+Agl1/FBoNti1YzCszaYNgLMRo/Re9mc3q0nYpYJKQzlV3YGzexBC+0mkbEnytfovRS5xSCrJ94T15XLsw9Eg==
+eslint-plugin-smarthr@^0.3.12:
+  version "0.3.12"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.3.12.tgz#26eab9128be523e8e4ff151f49297c2323410f37"
+  integrity sha512-C3Hti/vrRrWRwm2krFJUDf80JJYjkraMVDQRBaItBwvB1mPpq9WaOr6ksU4F+erybEucONt/7odsujgPzIkpAw==
   dependencies:
     inflected "^2.1.0"
     json5 "^2.2.0"


### PR DESCRIPTION
### [0.3.12](https://github.com/kufu/eslint-plugin-smarthr/compare/v0.3.11...v0.3.12) (2023-10-12)


### Features

* a11y-heading-in-sectioning-contentに"SectioningContent内のsmarthr-ui/Heading系コンポーネントにtag属性が設定されている場合エラー"になる機能を追加 ([#85](https://github.com/kufu/eslint-plugin-smarthr/issues/85)) ([c34b4f4](https://github.com/kufu/eslint-plugin-smarthr/commit/c34b4f43da89d7baf48c2536dcd381327064ef75))
* a11y-image-has-alt-attributeでaria-describedbyが設定されている場合、エラーにならないように修正 ([#84](https://github.com/kufu/eslint-plugin-smarthr/issues/84)) ([046ee0f](https://github.com/kufu/eslint-plugin-smarthr/commit/046ee0f082381627343371235102304a3f2a0938))