### PR TITLE
feat: eslint-plugin-smarthrをupdate

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,12 @@ module.exports = {
     // original rules
     'smarthr/a11y-anchor-has-href-attribute': 'error',
     'smarthr/a11y-clickable-element-has-text': 'error',
+
+    // TODO: errorに変更する
     'smarthr/a11y-delegate-element-has-role-presentation': 'warn',
+    'smarthr/a11y-input-in-form-control': 'warn',
+    'smarthr/a11y-prohibit-useless-sectioning-fragment': 'warn',
+
     'smarthr/a11y-heading-in-sectioning-content': 'error',
     'smarthr/a11y-image-has-alt-attribute': 'error',
     'smarthr/a11y-input-has-name-attribute': 'error',

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-smarthr": "^0.3.24"
+    "eslint-plugin-smarthr": "^0.3.25"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@ eslint-plugin-react@^7.33.2:
     semver "^6.3.1"
     string.prototype.matchall "^4.0.8"
 
-eslint-plugin-smarthr@^0.3.24:
-  version "0.3.24"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.3.24.tgz#f7f1e5f6c468dbf5ee7370cd7a97467015e6be8c"
-  integrity sha512-4EEkIKs4hYpyilPc4h4tz8uoyJReJORY7FUMkXFdUgFr6eu2Pmf5nK44GRM6V3tJMw4jbH5r7+pR86JIUhVtTg==
+eslint-plugin-smarthr@^0.3.25:
+  version "0.3.25"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.3.25.tgz#fee92d2208e49163f784fce8743f453838d9c9c1"
+  integrity sha512-lX/Y8x+CmGGTsitD87iaH44G/V0T/NT2iKTE1dNOuGtAUAQlCtAYgnxi2ikOdq6q69VvZB6AkScoxrB/4Ejgyw==
   dependencies:
     inflected "^2.1.0"
     json5 "^2.2.0"


### PR DESCRIPTION
### [0.3.25](https://github.com/kufu/eslint-plugin-smarthr/compare/v0.3.24...v0.3.25) (2024-01-23)


### Features

* a11y-input-in-form-controlを追加する ([#98](https://github.com/kufu/eslint-plugin-smarthr/issues/98)) ([fb7e77d](https://github.com/kufu/eslint-plugin-smarthr/commit/fb7e77d8c3ac73f57425d094a240d998ff78a51d))
* a11y-prohibit-useless-sectioning-fragmentを追加する ([#106](https://github.com/kufu/eslint-plugin-smarthr/issues/106)) ([994c040](https://github.com/kufu/eslint-plugin-smarthr/commit/994c04027892a5fe50fb71ba8b5941401f12c02c))