### PR TITLE
feat: eslint-plugin-smarthrをv0.4.1にupdateする

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = {
     'smarthr/a11y-image-has-alt-attribute': 'error',
     'smarthr/a11y-input-has-name-attribute': 'error',
     'smarthr/a11y-input-in-form-control': 'error',
+    'smarthr/a11y-numbered-text-within-ol': 'warn', // TODO: 時期を見計らってerrorにする
     'smarthr/a11y-prohibit-input-placeholder': 'error',
     'smarthr/a11y-prohibit-useless-sectioning-fragment': 'error',
     'smarthr/a11y-trigger-has-button': 'error',

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "eslint": "^7.0.0 || ^8.0.0",
-    "eslint-plugin-smarthr": "^0.4.0",
+    "eslint-plugin-smarthr": "^0.4.1",
     "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
     "typescript": "^3.4.5 || ^4.0.0 || ^5.0.0"
   },
@@ -47,6 +47,6 @@
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-smarthr": "^0.4.0"
+    "eslint-plugin-smarthr": "^0.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@ eslint-plugin-react@^7.33.2:
     semver "^6.3.1"
     string.prototype.matchall "^4.0.8"
 
-eslint-plugin-smarthr@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.4.0.tgz#256681a222086c1ea56772410b713df045ce5b1b"
-  integrity sha512-iIDnMxkbthdKbx0EQZC1H++ZPqhH7GM+YDnG2u9VP/xjt1kc7X5mVdVsGbgmD/RaSOgzVQdq3JYKKzqNzkg96g==
+eslint-plugin-smarthr@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.4.1.tgz#85221f72458b3fce0160cb3016ea1a1a7e8ee2fa"
+  integrity sha512-ZZF5bG2lf9F3prZSIi6BMTKvX6VENrzzIx7oObSf5ZQQsQp88jnb3iC+DbVuBnUpAdHiT+DOZFLym5jxM+0KnQ==
   dependencies:
     json5 "^2.2.0"
 


### PR DESCRIPTION
* a11y-numbered-text-within-olを追加する ([#105](https://github.com/kufu/eslint-plugin-smarthr/issues/105)) ([167b92f](https://github.com/kufu/eslint-plugin-smarthr/commit/167b92f0f29db8ee9a446d25e09e04a7b11ce340))
* ComboBoxなどのinputAttributesでtitle属性が指定された場合、擬似的にラベルが付いていると判定するように修正 ([#113](https://github.com/kufu/eslint-plugin-smarthr/issues/113)) ([5f3b594](https://github.com/kufu/eslint-plugin-smarthr/commit/5f3b5943ec64a18d094a9c66627ad1db2bbabe08))