### PR TITLE
feat: eslint-plugin-smarthr@v0.4.2にupdate

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
     'smarthr/a11y-prohibit-input-placeholder': 'error',
     'smarthr/a11y-prohibit-useless-sectioning-fragment': 'error',
     'smarthr/a11y-trigger-has-button': 'error',
+    'smarthr/best-practice-for-button-element': 'warn', // TODO: 時期を見計らってerrorにする
     'smarthr/best-practice-for-date': 'error',
     'smarthr/best-practice-for-remote-trigger-dialog': 'error',
     'smarthr/format-import-path': 'off',

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "eslint": "^7.0.0 || ^8.0.0",
-    "eslint-plugin-smarthr": "^0.4.1",
+    "eslint-plugin-smarthr": "^0.4.2",
     "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
     "typescript": "^3.4.5 || ^4.0.0 || ^5.0.0"
   },
@@ -47,6 +47,6 @@
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-smarthr": "^0.4.1"
+    "eslint-plugin-smarthr": "^0.4.2"
   }
 }

--- a/test/__snapshots__/run.test.js.snap
+++ b/test/__snapshots__/run.test.js.snap
@@ -7,6 +7,7 @@ exports[`fixtures should match the snapshot 1`] = `
       "smarthr/a11y-delegate-element-has-role-presentation",
     ],
     "warnings": [
+      "smarthr/best-practice-for-button-element",
       "react/no-children-prop",
       "jsx-a11y/aria-role",
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@ eslint-plugin-react@^7.33.2:
     semver "^6.3.1"
     string.prototype.matchall "^4.0.8"
 
-eslint-plugin-smarthr@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.4.1.tgz#85221f72458b3fce0160cb3016ea1a1a7e8ee2fa"
-  integrity sha512-ZZF5bG2lf9F3prZSIi6BMTKvX6VENrzzIx7oObSf5ZQQsQp88jnb3iC+DbVuBnUpAdHiT+DOZFLym5jxM+0KnQ==
+eslint-plugin-smarthr@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-smarthr/-/eslint-plugin-smarthr-0.4.2.tgz#436196df3ff81806ba66a8b258bee6a452a6d66b"
+  integrity sha512-hdUobmlvVsXf7spRZBhoFbgp8kX9btTlZelcy805KeoWF+4ui3s9nvj2uBITSzaUhr2g0WM5KOOhNDhxmV8g6Q==
   dependencies:
     json5 "^2.2.0"
 


### PR DESCRIPTION
- button要素にtype属性の設定を促すルールをwarnで追加
  - https://github.com/kufu/eslint-plugin-smarthr/pull/115
- a11y-numbered-text-within-olを調整し、誤検知されないようにする
  - https://github.com/kufu/eslint-plugin-smarthr/pull/117