### PR TITLE
chore: eslint-plugin-smarthr を peerDependencies から外す

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is intended to use at a project for React + TypeScript.
 ## Install
 
 ```sh
-yarn add --dev eslint eslint-plugin-smarthr typescript react // install peerDependencies
+yarn add --dev eslint typescript react // install peerDependencies
 yarn add --dev eslint-config-smarthr
 ```
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "peerDependencies": {
     "eslint": "^7.0.0 || ^8.0.0",
-    "eslint-plugin-smarthr": "^0.5.10",
     "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
     "typescript": "^3.4.5 || ^4.0.0 || ^5.0.0"
   },


### PR DESCRIPTION
- #821

にて議論しましたが、やはり `eslint-config-smarthr` にとっては常に最新の `eslint-plugin-smarthr` を使用して欲しいという意図があると思うので、 `peerDependencies` から外して `dependencies` のみにします。

これによって、pnpm v9 であっても、最新の `eslint-config-smarthr` をインストールした場合はそこで定義されている最新の `eslint-plugin-smarthr` が使用されるようになります。
(pnpm v8 や yarn の場合は、`peerDependencies` と `dependencies` 両方定義してる場合に後者を優先してくれてたみたい)